### PR TITLE
fix: link directly to `zag` repo

### DIFF
--- a/site.config.ts
+++ b/site.config.ts
@@ -22,7 +22,7 @@ const siteConfig = {
     email: "sage@adebayosegun.com",
   },
   repo: {
-    url: baseConfig.repo,
+    url: "https://github.com/chakra-ui/zag",
     editUrl: `${baseConfig.repo}/edit/main/data`,
     blobUrl: `${baseConfig.repo}/blob/main`,
   },


### PR DESCRIPTION
The top GitHub icon link currently links to the `zag-docs` repo but I think that would be unexpected by most people. If I'm on a library's page and I see a GitHub icon in the nav, I'm clicking it because I want to see the library's codebase. 

Made a small change to make that a reality!