### PR TITLE
docs: update landing page Vue example to script setup

### DIFF
--- a/data/overview/installation.mdx
+++ b/data/overview/installation.mdx
@@ -54,32 +54,30 @@ export function Toggle() {
 > within the machine hook.
 > [Learn more](https://github.com/pmndrs/valtio#react-via-usesnapshot)
 
-### Usage with Vue 3 (JSX)
+### Usage with Vue 3 (<script setup>)
 
-Zag works seamlessly with Vue's JSX approach. Here's how to use the same toggle
+Zag works seamlessly with Vue's `<script setup>` sugar. Here's how to use the same toggle
 logic in Vue:
 
-```jsx
-import { computed, defineComponent, h, Fragment } from "vue"
+```html
+<script setup>
+import { computed } from "vue"
 import * as toggle from "@zag-js/toggle"
 import { useMachine, useSetup, normalizeProps } from "@zag-js/vue"
 
-export default defineComponent({
-  name: "Toggle",
-  setup() {
-    const [state, send] = useMachine(toggle.machine)
-    const ref = useSetup({ send, id: "1" })
-    const apiRef = computed(() => toggle.connect(state, send, normalizeProps))
-    return () => {
-      const api = apiRef.value
-      return (
-        <button ref={ref} {...api.buttonProps}>
-          {api.isPressed ? "On" : "Off"}
-        </button>
-      )
-    }
-  },
-})
+const [state, send] = useMachine(toggle.machine)
+const ref = useSetup({ send, id: "1" })
+
+const api = computed(() => 
+  toggle.connect(state.value, send, normalizeProps)
+)
+</script>
+
+<template>
+  <button ref="ref" v-bind="api.buttonProps">
+    {{ api.isPressed ? "On" : "Off" }}
+  </button>
+</template>
 ```
 
 There are some extra functions that need to be used in order to make it work:

--- a/data/snippets/vue/number-input/usage.mdx
+++ b/data/snippets/vue/number-input/usage.mdx
@@ -1,30 +1,24 @@
-```jsx
+```html
+<script setup lang="ts">
 import * as numberInput from "@zag-js/number-input"
 import { normalizeProps, useMachine, useSetup } from "@zag-js/vue"
-import { computed, defineComponent, h, Fragment } from "vue"
+import { computed } from "vue"
 
-export default defineComponent({
-  name: "NumberInput",
-  setup() {
-    const [state, send] = useMachine(numberInput.machine)
-    const ref = useSetup({ send, id: "1" })
-    const apiRef = computed(() =>
-      numberInput.connect(state.value, send, normalizeProps),
-    )
+const [state, send] = useMachine(numberInput.machine)
+const ref = useSetup({ send, id: "1" })
+const api = computed(() =>
+  numberInput.connect(state.value, send, normalizeProps)
+)
+</script>
 
-    return () => {
-      const api = apiRef.value
-      return (
-        <div ref={ref} {...api.rootProps}>
-          <label {...api.labelProps}>Enter number</label>
-          <div>
-            <button {...api.decrementButtonProps}>DEC</button>
-            <input {...api.inputProps} />
-            <button {...api.incrementButtonProps}>INC</button>
-          </div>
-        </div>
-      )
-    }
-  },
-})
+<template>
+  <div ref="ref" v-bind="api.rootProps">
+    <label v-bind="api.labelProps">Enter number</label>
+    <div>
+      <button v-bind="api.decrementButtonProps">DEC</button>
+      <input v-bind="api.inputProps" />
+      <button v-bind="api.incrementButtonProps">INC</button>
+    </div>
+  </div>
+</template>
 ```

--- a/data/snippets/vue/number-input/usage.mdx
+++ b/data/snippets/vue/number-input/usage.mdx
@@ -1,5 +1,5 @@
 ```html
-<script setup lang="ts">
+<script setup>
 import * as numberInput from "@zag-js/number-input"
 import { normalizeProps, useMachine, useSetup } from "@zag-js/vue"
 import { computed } from "vue"


### PR DESCRIPTION
This PR updates Vue snippets from JSX to [<script setup>](https://vuejs.org/api/sfc-script-setup.html#script-setup). It is the recommended syntax for SFC + Composition API.