### PR TITLE
Replace checkbox spec broken link

### DIFF
--- a/data/overview/whats-a-machine.mdx
+++ b/data/overview/whats-a-machine.mdx
@@ -71,7 +71,7 @@ The `machine` gives you access to these key information:
 
 Now that we've modelled the component logic, let's map that to DOM attributes
 and event handlers following the
-[WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/examples/checkbox/checkbox-1/checkbox-1.html)
+[WAI-ARIA](https://www.w3.org/TR/wai-aria-practices-1.1/examples/checkbox/checkbox-1/checkbox-1.html)
 specification for the switch component.
 
 We'll write a function called `connect` to do this.


### PR DESCRIPTION
Replaces the WAI-ARIA spec link for the switch component with the right one.