### PR TITLE
Fix typo in programmatic control

### DIFF
--- a/data/overview/programmatic-control.mdx
+++ b/data/overview/programmatic-control.mdx
@@ -15,10 +15,10 @@ programmatically.
 ## Setting initial context
 
 All machines have an "internal" context value that is used to manage extended
-state (or data) within the machine. To extend this intial value of this context,
-we allow uses pass it directly into the `machine` function.
+state (or data) within the machine. To extend this initial value of this context,
+we allow users pass it directly into the `machine` function.
 
-> This is used set/override the **initial** context value of the machine. It
+> This is used to set/override the **initial** context value of the machine. It
 > can't be updated later on. Keep reading to see how to update it.
 
 For example, if you want an accordion to start with a specific selected value.

--- a/data/overview/programmatic-control.mdx
+++ b/data/overview/programmatic-control.mdx
@@ -15,7 +15,7 @@ programmatically.
 ## Setting initial context
 
 All machines have an "internal" context value that is used to manage extended
-state (or data) within the machine. To extend this initial value of this context,
+state (or data) within the machine. To extend the initial value of this context,
 we allow users pass it directly into the `machine` function.
 
 > This is used to set/override the **initial** context value of the machine. It

--- a/data/overview/programmatic-control.mdx
+++ b/data/overview/programmatic-control.mdx
@@ -38,7 +38,7 @@ const [state, send] = useMachine(
 The `connect` method of the machines provide helpful methods (APIs) to change
 the machine state or update its context.
 
-> This approach is recommended approach to programmatically update a machine.
+> This approach is the recommended approach to programmatically update a machine.
 
 Let's say we'd like to change the expanded accordion item in an accordion group.
 Here's how to do that:


### PR DESCRIPTION
For this statement: "To extend this initial value of this context,
we allow users pass it directly into the `machine` function."

I think this reads better "To extend this initial value of this context,
we allow passing the value directly into the `machine` function."