### PR TITLE
fix: menu option item variable naming 

### DIFF
--- a/data/snippets/react/menu/option-items.mdx
+++ b/data/snippets/react/menu/option-items.mdx
@@ -36,7 +36,7 @@ export function Menu() {
             const option = { type: "radio", name: "order", value: item.id }
             return (
               <div key={item.id} {...api.getOptionItemProps(option)}>
-                {api.isOptionChecked(opts) ? "✅" : null} {item.label}
+                {api.isOptionChecked(option) ? "✅" : null} {item.label}
               </div>
             )
           })}
@@ -45,7 +45,7 @@ export function Menu() {
             const option = { type: "checkbox", name: "type", value: item.id }
             return (
               <div key={item.id} {...api.getOptionItemProps(option)}>
-                {api.isOptionChecked(opts) ? "✅" : null} {item.label}
+                {api.isOptionChecked(option) ? "✅" : null} {item.label}
               </div>
             )
           })}

--- a/data/snippets/vue/menu/option-items.mdx
+++ b/data/snippets/vue/menu/option-items.mdx
@@ -27,19 +27,19 @@ export default defineComponent({
           <div {...api.positionerProps}>
             <div {...api.contentProps}>
               {data.order.map((item) => {
-                const opts = { type: "radio", name: "order", value: item.id }
+                const option = { type: "radio", name: "order", value: item.id }
                 return (
-                  <div key={item.id} {...api.getOptionItemProps(opts)}>
-                    {api.isOptionChecked(opts) ? "✅" : null} {item.label}
+                  <div key={item.id} {...api.getOptionItemProps(option)}>
+                    {api.isOptionChecked(option) ? "✅" : null} {item.label}
                   </div>
                 )
               })}
               <hr {...api.separatorProps} />
               {data.type.map((item) => {
-                const opts = { type: "checkbox", name: "type", value: item.id }
+                const option = { type: "checkbox", name: "type", value: item.id }
                 return (
-                  <div key={item.id} {...api.getOptionItemProps(opts)}>
-                    {api.isOptionChecked(opts) ? "✅" : null} {item.label}
+                  <div key={item.id} {...api.getOptionItemProps(option)}>
+                    {api.isOptionChecked(option) ? "✅" : null} {item.label}
                   </div>
                 )
               })}


### PR DESCRIPTION
- Fixed wrong variable naming in react `menu` option item example. `opts` -> `option`
- Changed `opts` variable naming in same example for vue, so it's consistent with react and solid.