### PR TITLE
fix: typo in tags input example values -> value

### DIFF
--- a/data/components/tags-input.mdx
+++ b/data/components/tags-input.mdx
@@ -131,7 +131,7 @@ render the `hiddenInput` element.
 const [state, send] = useMachine(
   accordion.machine({
     name: "tags",
-    values: ["React", "Redux", "TypeScript"],
+    value: ["React", "Redux", "TypeScript"],
   }),
 )
 ```


### PR DESCRIPTION
fix: typo in tags input example values -> value