### PR TITLE
Fix: Update snippets Dialog backdropProps and PinInput onclick

### DIFF
--- a/data/snippets/react/dialog/usage.mdx
+++ b/data/snippets/react/dialog/usage.mdx
@@ -15,7 +15,7 @@ export function Dialog() {
       </button>
       {api.isOpen && (
         <Portal>
-          <div {...api.overlayProps} />
+          <div {...api.backdropProps} />
           <div {...api.underlayProps}>
             <div {...api.contentProps}>
               <h2 {...api.titleProps}>Edit profile</h2>

--- a/data/snippets/solid/dialog/usage.mdx
+++ b/data/snippets/solid/dialog/usage.mdx
@@ -16,7 +16,7 @@ export default function Page() {
       </button>
       {api().isOpen && (
         <Portal>
-          <div {...api().overlayProps} />
+          <div {...api().backdropProps} />
           <div {...api().underlayProps}>
             <div {...api().contentProps}>
               <h2 {...api().titleProps}>Edit profile</h2>

--- a/data/snippets/vue-jsx/dialog/usage.mdx
+++ b/data/snippets/vue-jsx/dialog/usage.mdx
@@ -21,7 +21,7 @@ export default defineComponent({
           </button>
           {api.isOpen && (
             <Teleport to="body">
-              <div {...api.overlayProps} />
+              <div {...api.backdropProps} />
               <div {...api.underlayProps}>
                 <div {...api.contentProps}>
                   <h2 {...api.titleProps}>Edit profile</h2>

--- a/data/snippets/vue-sfc/pin-input/usage.mdx
+++ b/data/snippets/vue-sfc/pin-input/usage.mdx
@@ -16,7 +16,7 @@ const api = computed(() => pinInput.connect(state.value, send, normalizeProps));
       <input v-bind="api.getInputProps({ index: 1 })" />
       <input v-bind="api.getInputProps({ index: 2 })" />
     </div>
-    <button onClick="api.clearValue">Clear</button>
+    <button @click="api.clearValue">Clear</button>
   </div>
 </template>
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- The Dialog Component Snippets are updated with `backdropProps` instead of `overlayProps`.
- The PinInput Component Vue SFC Snippet is updated with `@click` instead of `onClick` as event.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
