### PR TITLE
chore: document individual spin buttons styling

### DIFF
--- a/data/components/number-input.mdx
+++ b/data/components/number-input.mdx
@@ -279,3 +279,17 @@ added.
   /* readonly styles for the input */
 }
 ```
+
+### Spin buttons
+
+The spin buttons can be styled individually with the `data-type` attribute.
+
+```css
+[data-part="spin-button"][data-type="increment"] {
+  /* styles for the increment spin button */
+}
+
+[data-part="spin-button"][data-type="decrement"] {
+  /* styles for the decrement spin button */
+}
+```


### PR DESCRIPTION
Add `data-type` styling guide for number input spin buttons to docs