### PR TITLE
chore: add `getRootNode` guide to composition docs

### DIFF
--- a/data/overview/composition.mdx
+++ b/data/overview/composition.mdx
@@ -96,38 +96,44 @@ return </>
 In the example above, you will notice that the popover and tooltip trigger share
 the same id. That's how to compose machines together.
 
-## Document composition
+## Custom window environment
 
-As mentioned in the [Id composition](#id-composition) section, we track elements
-with `document.getElementById`. In custom windows like html's `iframe`, Electron
-or Tauri, the native browser document would not be available. In this case, you
-have resolve the document and pass it to the machine's context with the
-`getRootNode` method
+Internally, we use DOM query methods like `document.querySelectorAll` and
+`document.getElementById` to locate elements within the machine.
+
+In custom environments like iframe, Shadow DOM, Electron, etc., the machine
+might not work as expected because `document` may not be available.
+
+To provide the correct reference to root node or document, you can pass
+`getRootNode` function it to the machine's context.
+
+> In shadow DOM, the root node can be derived from calling
+> `element.getRootNode()` method on any element.
 
 ```jsx {12,15,42}
-import * as accordion from "@zag-js/accordion";
-import { useMachine, normalizeProps } from "@zag-js/react";
-import Frame, { useFrame } from "react-frame-component";
+import * as accordion from "@zag-js/accordion"
+import { useMachine, normalizeProps } from "@zag-js/react"
+import Frame, { useFrame } from "react-frame-component"
 
 const data = [
   { title: "Watercraft", content: "Sample accordion content" },
   { title: "Automobiles", content: "Sample accordion content" },
-  { title: "Aircrafts", content: "Sample accordion content" }
-];
+  { title: "Aircrafts", content: "Sample accordion content" },
+]
 
-function Accordion({ id }: any) {
-  const { document } = useFrame();
+function Accordion({ id }) {
+  const { document } = useFrame()
 
   const [state, send] = useMachine(
-    accordion.machine({ id, getRootNode: () => document! })
-  );
+    accordion.machine({ id, getRootNode: () => document }),
+  )
 
-  const api = accordion.connect(state, send, normalizeProps);
+  const api = accordion.connect(state, send, normalizeProps)
 
   return (
     <div {...api.rootProps}>
-      {data.map((item, i) => (
-        <div key={i} {...api.getItemProps({ value: item.title })}>
+      {data.map((item, index) => (
+        <div key={index} {...api.getItemProps({ value: item.title })}>
           <h3>
             <button {...api.getTriggerProps({ value: item.title })}>
               {item.title}
@@ -139,7 +145,7 @@ function Accordion({ id }: any) {
         </div>
       ))}
     </div>
-  );
+  )
 }
 
 export default function App() {
@@ -150,6 +156,6 @@ export default function App() {
         <Accordion id="2" />
       </Frame>
     </div>
-  );
+  )
 }
 ```

--- a/data/overview/composition.mdx
+++ b/data/overview/composition.mdx
@@ -19,9 +19,11 @@ import { useMachine, mergeProps } from "@zag-js/react"
 import * as toggle from "@zag-js/toggle"
 
 export function Toggle() {
-  const [state, send] = useMachine(toggle.machine({
-     id: "1"
-  }))
+  const [state, send] = useMachine(
+    toggle.machine({
+      id: "1",
+    }),
+  )
   const api = toggle.connect(state, send)
 
   // 2. write your custom event handlers
@@ -36,9 +38,7 @@ export function Toggle() {
 
   return (
     // 4. spread the new props
-    <button {...buttonProps}>
-      {api.isPressed ? "On" : "Off"}
-    </button>
+    <button {...buttonProps}>{api.isPressed ? "On" : "Off"}</button>
   )
 }
 ```
@@ -48,8 +48,8 @@ export function Toggle() {
 Zag depends heavily on pure DOM queries to identify elements. This means every
 element part needs to have a unique id.
 
-Each time you initiate the machine with the `useMachine` hook, you'll need to ensure that you provide a
-unique id.
+Each time you initiate the machine with the `useMachine` hook, you'll need to
+ensure that you provide a unique id.
 
 You can rely on framework-specific utilities to generate unique ids. React
 provides `useId()` hook and Solid.js provides a `createId()` function for this
@@ -95,3 +95,61 @@ return </>
 
 In the example above, you will notice that the popover and tooltip trigger share
 the same id. That's how to compose machines together.
+
+## Document composition
+
+As mentioned in the [Id composition](#id-composition) section, we track elements
+with `document.getElementById`. In custom windows like html's `iframe`, Electron
+or Tauri, the native browser document would not be available. In this case, you
+have resolve the document and pass it to the machine's context with the
+`getRootNode` method
+
+```jsx {12,15,42}
+import * as accordion from "@zag-js/accordion";
+import { useMachine, normalizeProps } from "@zag-js/react";
+import Frame, { useFrame } from "react-frame-component";
+
+const data = [
+  { title: "Watercraft", content: "Sample accordion content" },
+  { title: "Automobiles", content: "Sample accordion content" },
+  { title: "Aircrafts", content: "Sample accordion content" }
+];
+
+function Accordion({ id }: any) {
+  const { document } = useFrame();
+
+  const [state, send] = useMachine(
+    accordion.machine({ id, getRootNode: () => document! })
+  );
+
+  const api = accordion.connect(state, send, normalizeProps);
+
+  return (
+    <div {...api.rootProps}>
+      {data.map((item, i) => (
+        <div key={i} {...api.getItemProps({ value: item.title })}>
+          <h3>
+            <button {...api.getTriggerProps({ value: item.title })}>
+              {item.title}
+            </button>
+          </h3>
+          <div {...api.getContentProps({ value: item.title })}>
+            {item.content}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <div className="App">
+      <h1>ZagJs in Iframe</h1>
+      <Frame height="200px" width="100%">
+        <Accordion id="2" />
+      </Frame>
+    </div>
+  );
+}
+```

--- a/data/overview/faq.mdx
+++ b/data/overview/faq.mdx
@@ -30,11 +30,11 @@ frameworks like React, Solid and Vue. Here are some examples:
 These little nuances between frameworks are handled automatically when you use
 `normalizeProps`.
 
-## How do I attach custom extra event handlers to the elements?
+## How can I attach custom extra event handlers to the elements?
 
 See the approach [here](/overview/composition#event-composition).
 
-## How do get Zag working in a custom window environment?
+## How can I get Zag working in a custom window environment?
 
 See the approach [here](/overview/composition#custom-window-environment).
 

--- a/data/overview/faq.mdx
+++ b/data/overview/faq.mdx
@@ -34,6 +34,10 @@ These little nuances between frameworks are handled automatically when you use
 
 See the approach [here](/overview/composition#event-composition).
 
+## How do get Zag working in a custom window environment?
+
+See the approach [here](/overview/composition#custom-window-environment).
+
 ## What would it take to support other frameworks?
 
 We're currently interested in supporting as many frameworks as possible. The key


### PR DESCRIPTION
Closes #49 

Add `getRootNode` guide to composition docs