### PR TITLE
Fix(docs): update nested menu vue example snippets

### DIFF
--- a/data/snippets/vue-jsx/menu/nested-menu.mdx
+++ b/data/snippets/vue-jsx/menu/nested-menu.mdx
@@ -28,7 +28,7 @@ export default defineComponent({
     )
 
     const shareMenuApi = computed(() =>
-      menu.connect(subState.value, subSend, normalizeProps),
+      menu.connect(shareMenuState.value, shareMenuSend, normalizeProps),
     )
 
     onMounted(() => {
@@ -38,8 +38,9 @@ export default defineComponent({
       })
     })
 
+    // Share menu trigger
     const shareMenuTriggerProps = computed(() =>
-      shareMenuApi.value.getTriggerItemProps(shareMenuApi),
+      fileMenu.value.getTriggerItemProps(shareMenu.value)
     )
 
     return () => {

--- a/data/snippets/vue-jsx/menu/nested-menu.mdx
+++ b/data/snippets/vue-jsx/menu/nested-menu.mdx
@@ -40,7 +40,7 @@ export default defineComponent({
 
     // Share menu trigger
     const shareMenuTriggerProps = computed(() =>
-      fileMenu.value.getTriggerItemProps(shareMenu.value)
+      fileMenu.value.getTriggerItemProps(shareMenuApi.value)
     )
 
     return () => {

--- a/data/snippets/vue-sfc/menu/nested-menu.mdx
+++ b/data/snippets/vue-sfc/menu/nested-menu.mdx
@@ -18,8 +18,8 @@ const [shareMenuState, shareMenuSend, shareMenuMachine] = useMachine(
   menu.machine({ id:"2", "aria-label": "Share" })
 );
 
-const shareMenu = computed(() =>
-  menu.connect(subState.value, subSend, normalizeProps)
+const shareMenu = computed(() => 
+  menu.connect(shareMenuState.value, shareMenuSend, normalizeProps)
 );
 
 onMounted(() => {
@@ -28,6 +28,12 @@ onMounted(() => {
     shareMenu.value.setParent(fileMenuMachine);
   });
 });
+
+// Share menu trigger
+const shareMenuTriggerProps = computed(() => 
+  fileMenu.value.getTriggerItemProps(shareMenu.value)
+);
+
 </script>
 
 <template>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Computed value shareMenu had incorrect params passed to it
- Missing shareMenuTriggerprops computed value

Stackblitz example: https://stackblitz.com/edit/vue3-script-setup-with-vite-gaqgbq?file=src/App.vue

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
