### PR TITLE
fix typo on select methods documentation

### DIFF
--- a/data/components/select.mdx
+++ b/data/components/select.mdx
@@ -218,8 +218,8 @@ The select's `api` exposes the following methods:
 - `isOpen` — Checks if the select is open.
 - `highlightedOption` - The highlighted option.
 - `selectedOption` - Selects an option.
-- `blur(...)` — Function to focus the select.
-- `focus(...)` — Function to blur the select.
+- `blur(...)` — Function to blur the select.
+- `focus(...)` — Function to focus the select.
 - `open(...)` — Function to open the select.
 - `close(...)` — Function to close the select.
 - `setSelectionOption(...)` — Function to set the selected option.


### PR DESCRIPTION
hello,

just fixing a small typo I spotted when reading through the documentation

cheers