### PR TITLE
fix toast usage for solid / react

### DIFF
--- a/data/snippets/react/toast/usage.mdx
+++ b/data/snippets/react/toast/usage.mdx
@@ -22,7 +22,7 @@ const ToastContext = createContext()
 const useToast = () => useContext(ToastContext)
 
 // 3. Create the toast group provider
-export function ToastProvider() {
+export function ToastProvider({ children }) {
   const [state, send] = useMachine(toast.group.machine({ id: "1" }))
 
   const api = toast.group.connect(state, send, normalizeProps)
@@ -36,6 +36,8 @@ export function ToastProvider() {
           ))}
         </div>
       ))}
+
+      {children}
     </ToastContext.Provider>
   )
 }

--- a/data/snippets/solid/toast/usage.mdx
+++ b/data/snippets/solid/toast/usage.mdx
@@ -1,7 +1,7 @@
 ```jsx
 import { useActor, useMachine, normalizeProps } from "@zag-js/solid"
 import * as toast from "@zag-js/toast"
-import { createMemo, createUniqueId, createSignal, createContext, useContext } from "solid-js"
+import { createMemo, createUniqueId, createSignal, createContext, useContext, For } from "solid-js"
 
 // 1. Create the single toast
 function Toast(props) {
@@ -22,20 +22,26 @@ const ToastContext = createContext()
 const useToast = () => useContext(ToastContext)
 
 // 3. Create the toast group provider
-export function ToastProvider() {
+export function ToastProvider(props) {
   const [state, send] = useMachine(toast.group.machine({  id: createUniqueId() }))
 
   const api = createMemo(() => toast.group.connect(state, send, normalizeProps))
 
   return (
     <ToastContext.Provider value={api}>
-      {Object.entries(api().toastsByPlacement).map(([placement, toasts]) => (
-        <div key={placement} {...api().getGroupProps({ placement })}>
-          {toasts.map((toast) => (
-            <Toast key={toast.id} actor={toast} />
-          ))}
-        </div>
-      ))}
+      <For each={Object.entries(api().toastsByPlacement)}>
+        {([placement, toasts]) => (
+          <div key={placement} {...api().getGroupProps({ placement })}>
+            <For each={toasts}>
+              {(toast) => (
+                <Toast key={toast.id} actor={toast} />
+              )}
+            </For>
+          </div>
+        )}
+      </For>
+
+      {props.children}
     </ToastContext.Provider>
   )
 }
@@ -57,7 +63,7 @@ function ExampleComponent() {
     <div>
       <button
         onClick={() => {
-          toast.create({ title: "Hello", placement: "top-right" })
+          toast().create({ title: "Hello", placement: "top-right" })
         }}
       >
         Add top-right toast


### PR DESCRIPTION
hello

i noticed some errors in the toast doc for solid and react

for solid.js:
- change `map` example to use `For` instead as `map` will not be reactive in solid.js
- added `props.children` to render the children from the `ToastProvider`
- fix the usage example to use the function accessor for `toast` as it's a signal

for react:
- added `props.children` to render the children from the `ToastProvider`

cheers