### PR TITLE
fix select machine typo

### DIFF
--- a/data/snippets/solid/select/usage-with-form.mdx
+++ b/data/snippets/solid/select/usage-with-form.mdx
@@ -15,7 +15,7 @@ const selectData = [
 
 export function SelectWithForm() {
   const [state, send] = useMachine(
-    menu.machine({ id: createUniqueId(), name: "country" }),
+    select.machine({ id: createUniqueId(), name: "country" }),
   )
 
   const api = createMemo(() => select.connect(state, send, normalizeProps))


### PR DESCRIPTION
Fix typo on machine "menu", should be "select".